### PR TITLE
Use XenForo database connection

### DIFF
--- a/Service/SessionValidator.php
+++ b/Service/SessionValidator.php
@@ -9,20 +9,17 @@ namespace WindowsForum\SessionValidator\Service;
  * that can be used in Cloudflare security rules for enhanced authentication.
  * 
  * Based on the proven gold standard xenforo-session-validator.php
+ *
+ * This version uses \XF::db() to access XenForo's configured
+ * database connection rather than creating a new PDO instance.
  */
 class SessionValidator
 {
-    private $config;
     private $db;
     
     public function __construct()
     {
-        // Load XenForo config
-        $configPath = \XF::getRootDirectory() . '/src/config.php';
-        if (file_exists($configPath))
-        {
-            $this->config = require $configPath;
-        }
+        // Uses XenForo's built-in database connection
     }
     
     /**
@@ -198,23 +195,10 @@ class SessionValidator
         {
             return $this->db;
         }
-        
-        if (!$this->config || !isset($this->config['db']))
-        {
-            return null;
-        }
-        
+
         try
         {
-            $dbConfig = $this->config['db'];
-            $dsn = "mysql:host={$dbConfig['host']};port={$dbConfig['port']};dbname={$dbConfig['dbname']};charset=utf8mb4";
-            
-            $this->db = new \PDO($dsn, $dbConfig['username'], $dbConfig['password'], [
-                \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
-                \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
-                \PDO::ATTR_TIMEOUT => 5
-            ]);
-            
+            $this->db = \XF::db();
             return $this->db;
         }
         catch (\Exception $e)


### PR DESCRIPTION
## Summary
- use `\XF::db()` instead of building our own `PDO` connection
- document usage of XenForo DB connection in the service

## Testing
- `php -l Service/SessionValidator.php`

------
https://chatgpt.com/codex/tasks/task_e_683f688f45a48321afc8e0e377970ff0